### PR TITLE
feat: add support for visual studio 2022 preview 1

### DIFF
--- a/OneDarkPro/OneDarkPro.csproj
+++ b/OneDarkPro/OneDarkPro.csproj
@@ -35,6 +35,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DeployExtension>True</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -58,7 +59,10 @@
     <PackageReference Include="Microsoft.VisualStudio.VsixColorCompiler">
       <Version>16.0.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.1.3132" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.1619-preview1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="icon.png">

--- a/OneDarkPro/source.extension.vsixmanifest
+++ b/OneDarkPro/source.extension.vsixmanifest
@@ -8,15 +8,15 @@
         <Tags>Atom, One Dark Pro, Theme</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
-        <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[16.0,17.0]" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[16.0,17.0]" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[16.0,17.0]" Id="Microsoft.VisualStudio.Pro" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0]" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />

--- a/OneDarkPro/source.extension.vsixmanifest
+++ b/OneDarkPro/source.extension.vsixmanifest
@@ -8,9 +8,25 @@
         <Tags>Atom, One Dark Pro, Theme</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Version="[16.0,17.0]" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[16.0,17.0]" Id="Microsoft.VisualStudio.Enterprise" />
-        <InstallationTarget Version="[16.0,17.0]" Id="Microsoft.VisualStudio.Pro" />
+      <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Community">
+        <ProductArchitecture>x86</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Enterprise">
+        <ProductArchitecture>x86</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Pro">
+        <ProductArchitecture>x86</ProductArchitecture>
+      </InstallationTarget>
+
+      <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
A simple target version range update to allow Dark One Pro to run under Visual Studio 2022 Preview 1