### PR TITLE
Improves vertical tab theming

### DIFF
--- a/OneDarkPro/OneDarkPro.vstheme
+++ b/OneDarkPro/OneDarkPro.vstheme
@@ -6426,14 +6426,17 @@
       <Color Name="Halo">
         <Background Type="CT_RAW" Source="FFF6F6F6" />
       </Color>
+      <Color Name="FileTabParentText">
+        <Background Type="CT_RAW" Source="FFBDBDBD" />
+      </Color>
       <Color Name="FileTabGroupTitleBackground">
         <Background Type="CT_RAW" Source="FF2E323A" />
       </Color>
       <Color Name="FileTabActiveGroupTitleBackground">
-        <Background Type="CT_RAW" Source="FF2E323A" />
+        <Background Type="CT_RAW" Source="FF3E4249" />
       </Color>
       <Color Name="FileTabActiveGroupBackground">
-        <Background Type="CT_RAW" Source="FF2E323A" />
+        <Background Type="CT_RAW" Source="FF313741" />
       </Color>
     </Category>
     <Category Name="Find" GUID="{4370282e-987e-4ac4-ad14-5ffed2ad1e14}">


### PR DESCRIPTION
The current theme has issues with vertical tabs that can be seen in issues #20 and #14 . 

This PR includes the addition of a missing field in the theme and modifications to others to make vertical tabs more usable. 

**Note:** I used colors already included in the theme and created an additional color inspired by how the default dark theme handles vertical tabs. (They also created a unique color for this). Please let me know if you prefer different colors than the ones I selected and I would be happy to change them.

Inactive state:
![image](https://user-images.githubusercontent.com/46940941/125139729-eaf47300-e0c5-11eb-827c-cfe9ff182771.png)

Active state:
![image](https://user-images.githubusercontent.com/46940941/125139780-019aca00-e0c6-11eb-96e7-6b2674e2fb88.png)
